### PR TITLE
Persist scheduled replies across restarts

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -47,6 +47,7 @@ DEFAULT_CONFIG = {
 }
 
 CONFIG_FILE_NAME = os.environ.get('HUTBOT_CONFIG_FILE', 'bot.json')
+SCHEDULED_REPLIES_CACHE_FILE = os.environ.get('HUTBOT_SCHEDULED_REPLIES_CACHE_FILE', 'scheduled_replies.json')
 TEAM_UNKNOWN = '<unknown>'
 
 IGNORED_MESSAGE_SUBTYPES = set(['channel_join',
@@ -62,6 +63,7 @@ IGNORED_MESSAGE_SUBTYPES = set(['channel_join',
 
 channel_config = {}
 scheduled_messages = {}
+_scheduled_replies_cache: dict[tuple, dict] = {}
 
 user_id_cache = {}
 user_email_cache = {}
@@ -190,6 +192,30 @@ async def save_configuration() -> None:
             await f.write(content)
     except Exception as e:
         log_error("Failed to save configuration:", e)
+
+async def load_replies_cache() -> None:
+    global _scheduled_replies_cache
+    try:
+        async with aiofiles.open(SCHEDULED_REPLIES_CACHE_FILE, 'r') as f:
+            content = await f.read()
+            entries = json.loads(content)
+            _scheduled_replies_cache = {
+                (e['channel_id'], e['ts'], e['config_name']): e
+                for e in entries
+            }
+            log(f"Loaded {len(_scheduled_replies_cache)} pending scheduled replies from cache.")
+    except FileNotFoundError:
+        _scheduled_replies_cache = {}
+    except Exception as e:
+        log_error("Failed to load scheduled replies cache:", e)
+        _scheduled_replies_cache = {}
+
+async def flush_replies_cache() -> None:
+    try:
+        async with aiofiles.open(SCHEDULED_REPLIES_CACHE_FILE, 'w') as f:
+            await f.write(json.dumps(list(_scheduled_replies_cache.values()), indent=2))
+    except Exception as e:
+        log_error("Failed to flush scheduled replies cache:", e)
 
 async def get_channel_by_id(app: AsyncApp, channel_id: str) -> Channel:
     global channel_config
@@ -960,14 +986,15 @@ async def get_opsgenie_template_variables(app: AsyncApp, opsgenie_token: str, co
 
     return variables
 
-async def schedule_reply(app: AsyncApp, opsgenie_token: str, channel: Channel, config: dict, config_name: str, user: User, text: str, ts: str) -> None:
+async def schedule_reply(app: AsyncApp, opsgenie_token: str, channel: Channel, config: dict, config_name: str, user: User, text: str, ts: str, wait_time_override: float | None = None) -> None:
     opsgenie_enabled = config.get('opsgenie')
     wait_time = config.get('wait_time')
     reply_message_template = config.get('reply_message')
     scheduled_message_key = (channel.id, ts, config_name)
+    actual_wait = wait_time_override if wait_time_override is not None else wait_time
     log(f"Scheduling reply for message {ts} in channel #{channel.name} for config '{config_name}', user @{user.name}, wait time {wait_time // 60} mins, opsgenie {'enabled' if opsgenie_enabled else 'disabled'}{', but not configured' if opsgenie_enabled and not opsgenie_configured else ''}")
     try:
-        await asyncio.sleep(wait_time)
+        await asyncio.sleep(actual_wait)
         permalink = await get_message_permalink(app, channel, ts)
         template_variables = find_template_variables(reply_message_template)
         opsgenie_template_variables = {}
@@ -996,6 +1023,8 @@ async def schedule_reply(app: AsyncApp, opsgenie_token: str, channel: Channel, c
         log_error(f"Failed to send scheduled reply for message {ts} in channel #{channel.name} for config '{config_name}', user @{user.name}:", e)
     finally:
         scheduled_messages.pop(scheduled_message_key, None)
+        _scheduled_replies_cache.pop(scheduled_message_key, None)
+        await flush_replies_cache()
 
 async def replace_ids(app: AsyncApp, channel: Channel | None, text: str) -> str:
     for match in ID_PATTERN.finditer(text):
@@ -1214,6 +1243,16 @@ async def handle_channel_message(app: AsyncApp, opsgenie_token: str, channel: Ch
 
         task = asyncio.create_task(schedule_reply(app, opsgenie_token, channel, config, config_name, user, text, ts))
         scheduled_messages[(channel.id, ts, config_name)] = ScheduledReply(task, user.id)
+        send_at = datetime.datetime.now() + datetime.timedelta(seconds=config['wait_time'])
+        _scheduled_replies_cache[(channel.id, ts, config_name)] = {
+            'channel_id': channel.id,
+            'ts': ts,
+            'config_name': config_name,
+            'user_id': user.id,
+            'text': text,
+            'send_at': send_at.isoformat(),
+        }
+        await flush_replies_cache()
 
 async def handle_reaction_added(app: AsyncApp, event):
     item = event.get('item', {})
@@ -1285,6 +1324,34 @@ def register_app_handlers(app: AsyncApp, opsgenie_token: str = "") -> None:
         await ack()
         await handle_command_event(app, body)
 
+async def restore_scheduled_replies(app: AsyncApp, opsgenie_token: str) -> None:
+    entries = list(_scheduled_replies_cache.items())
+    invalid_keys = []
+    restored = 0
+    log(f"Restoring {len(entries)} scheduled replies from cache...")
+    for key, entry in entries:
+        channel_id = entry['channel_id']
+        ts = entry['ts']
+        config_name = entry['config_name']
+        if channel_id not in channel_config or config_name not in channel_config[channel_id]:
+            log_warning(f"Skipping cached reply for message {ts}: channel {channel_id} / config '{config_name}' no longer configured.")
+            invalid_keys.append(key)
+            continue
+        config = channel_config[channel_id][config_name]
+        channel = await get_channel_by_id(app, channel_id)
+        user = await get_user_by_id(app, entry['user_id'])
+        send_at = datetime.datetime.fromisoformat(entry['send_at'])
+        remaining = max(0.0, (send_at - datetime.datetime.now()).total_seconds())
+        log(f"Restoring reply for message {ts} in channel #{channel.name} for config '{config_name}', user @{user.name}, remaining {remaining:.0f}s.")
+        task = asyncio.create_task(schedule_reply(app, opsgenie_token, channel, config, config_name, user, entry['text'], ts, wait_time_override=remaining))
+        scheduled_messages[(channel.id, ts, config_name)] = ScheduledReply(task, user.id)
+        restored += 1
+    for key in invalid_keys:
+        _scheduled_replies_cache.pop(key, None)
+    if invalid_keys:
+        await flush_replies_cache()
+    log(f"Restored {restored} scheduled replies.")
+
 async def send_heartbeat(opsgenie_token: str, opsgenie_heartbeat_name: str) -> None:
     url = 'https://api.opsgenie.com/v2/heartbeats/' + opsgenie_heartbeat_name + '/ping'
     headers = {
@@ -1319,6 +1386,8 @@ async def main() -> None:
         global bot_user_id
         bot_user_id = (await app.client.auth_test())["user_id"]
         await update_user_cache(app)
+        await load_replies_cache()
+        await restore_scheduled_replies(app, opsgenie_token)
         register_app_handlers(app, opsgenie_token=opsgenie_token)
         handler = AsyncSocketModeHandler(app, slack_app_token)
         if opsgenie_token and opsgenie_heartbeat_name:

--- a/test_bot.py
+++ b/test_bot.py
@@ -1,13 +1,18 @@
 import pytest
 import datetime
 from unittest.mock import AsyncMock, patch, call, MagicMock
+import json
+import tempfile
+import os
 from bot import (
     replace_ids, Channel, User, Usergroup, get_team_of, process_command,
     clean_slack_text, send_message, route_message, handle_channel_message,
     scheduled_messages, set_work_hours, parse_time, is_work_day, is_work_time,
     DEFAULT_CONFIG, migrate_and_apply_defaults, set_pattern, show_config,
     handle_thread_response, handle_reaction_added, handle_message_deletion,
-    ScheduledReply, set_reply_message, schedule_reply
+    ScheduledReply, set_reply_message, schedule_reply,
+    load_replies_cache, flush_replies_cache, restore_scheduled_replies,
+    _scheduled_replies_cache,
 )
 from slack_sdk.errors import SlackApiError
 import base64
@@ -513,3 +518,150 @@ async def test_schedule_reply_keeps_plain_message_unchanged():
 
         mock_get_opsgenie_template_variables.assert_not_awaited()
         mock_send_message.assert_called_with(app, channel, user, "Anybody?", "1234.1")
+
+@pytest.mark.asyncio
+async def test_load_and_flush_replies_cache_roundtrip():
+    import bot
+    entry = {
+        'channel_id': 'C123',
+        'ts': '1000.1',
+        'config_name': 'default',
+        'user_id': 'U456',
+        'text': 'hello',
+        'send_at': '2026-04-23T13:00:00',
+    }
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        json.dump([entry], f)
+        tmp_path = f.name
+
+    try:
+        with patch('bot.SCHEDULED_REPLIES_CACHE_FILE', tmp_path):
+            bot._scheduled_replies_cache.clear()
+            await load_replies_cache()
+            assert ('C123', '1000.1', 'default') in bot._scheduled_replies_cache
+
+            bot._scheduled_replies_cache[('C123', '1000.1', 'default')]['text'] = 'updated'
+            await flush_replies_cache()
+
+            with open(tmp_path) as f:
+                data = json.load(f)
+            assert data[0]['text'] == 'updated'
+    finally:
+        os.unlink(tmp_path)
+        bot._scheduled_replies_cache.clear()
+
+@pytest.mark.asyncio
+async def test_load_replies_cache_handles_missing_file():
+    import bot
+    with patch('bot.SCHEDULED_REPLIES_CACHE_FILE', '/nonexistent/path/to/cache.json'):
+        bot._scheduled_replies_cache.clear()
+        await load_replies_cache()
+        assert bot._scheduled_replies_cache == {}
+
+@pytest.mark.asyncio
+async def test_restore_scheduled_replies_skips_unknown_channel():
+    import bot
+    bot._scheduled_replies_cache.clear()
+    bot._scheduled_replies_cache[('C_GONE', '1000.1', 'default')] = {
+        'channel_id': 'C_GONE',
+        'ts': '1000.1',
+        'config_name': 'default',
+        'user_id': 'U1',
+        'text': 'msg',
+        'send_at': (datetime.datetime.now() + datetime.timedelta(seconds=60)).isoformat(),
+    }
+    app = AsyncMock()
+    scheduled_messages.clear()
+
+    with patch('bot.channel_config', {}), patch('bot.flush_replies_cache', new=AsyncMock()):
+        await restore_scheduled_replies(app, "token")
+
+    assert len(scheduled_messages) == 0
+    assert bot._scheduled_replies_cache == {}
+
+@pytest.mark.asyncio
+async def test_restore_scheduled_replies_schedules_with_remaining_time():
+    import bot
+    import asyncio
+    future = datetime.datetime.now() + datetime.timedelta(seconds=300)
+    bot._scheduled_replies_cache.clear()
+    bot._scheduled_replies_cache[('C123', '1000.1', 'default')] = {
+        'channel_id': 'C123',
+        'ts': '1000.1',
+        'config_name': 'default',
+        'user_id': 'U456',
+        'text': 'hello',
+        'send_at': future.isoformat(),
+    }
+    config = {**DEFAULT_CONFIG.copy(), 'wait_time': 1800}
+    app = AsyncMock()
+    app.client.conversations_info.return_value = {'channel': {'name': 'general'}}
+    scheduled_messages.clear()
+
+    captured_override = []
+
+    async def fake_schedule_reply(*args, wait_time_override=None, **kwargs):
+        captured_override.append(wait_time_override)
+
+    with patch('bot.channel_config', {'C123': {'default': config}}), \
+         patch('bot.get_user_by_id', new=AsyncMock(return_value=User('U456', 'user', 'User', 'Team'))), \
+         patch('bot.schedule_reply', side_effect=fake_schedule_reply), \
+         patch('bot.flush_replies_cache', new=AsyncMock()):
+        await restore_scheduled_replies(app, "token")
+        await asyncio.gather(*[sr.task for sr in scheduled_messages.values()])
+
+    assert len(captured_override) == 1
+    assert 290 <= captured_override[0] <= 310
+
+@pytest.mark.asyncio
+async def test_restore_scheduled_replies_sends_immediately_when_overdue():
+    import bot
+    import asyncio
+    past = datetime.datetime.now() - datetime.timedelta(seconds=60)
+    bot._scheduled_replies_cache.clear()
+    bot._scheduled_replies_cache[('C123', '1000.1', 'default')] = {
+        'channel_id': 'C123',
+        'ts': '1000.1',
+        'config_name': 'default',
+        'user_id': 'U456',
+        'text': 'hello',
+        'send_at': past.isoformat(),
+    }
+    config = {**DEFAULT_CONFIG.copy(), 'wait_time': 1800}
+    app = AsyncMock()
+    app.client.conversations_info.return_value = {'channel': {'name': 'general'}}
+    scheduled_messages.clear()
+
+    captured_override = []
+
+    async def fake_schedule_reply(*args, wait_time_override=None, **kwargs):
+        captured_override.append(wait_time_override)
+
+    with patch('bot.channel_config', {'C123': {'default': config}}), \
+         patch('bot.get_user_by_id', new=AsyncMock(return_value=User('U456', 'user', 'User', 'Team'))), \
+         patch('bot.schedule_reply', side_effect=fake_schedule_reply), \
+         patch('bot.flush_replies_cache', new=AsyncMock()):
+        await restore_scheduled_replies(app, "token")
+        await asyncio.gather(*[sr.task for sr in scheduled_messages.values()])
+
+    assert captured_override[0] == 0.0
+
+@pytest.mark.asyncio
+async def test_schedule_reply_removes_entry_from_cache():
+    import bot
+    app = AsyncMock()
+    app.client.chat_getPermalink.return_value = {"permalink": ""}
+    channel = Channel(id="C12345", name="general", configs={})
+    user = User("U12345", "test", "Test User", "Testers")
+    config = DEFAULT_CONFIG.copy()
+    config["wait_time"] = 0
+    ts = "9999.1"
+    key = (channel.id, ts, "default")
+
+    bot._scheduled_replies_cache.clear()
+    bot._scheduled_replies_cache[key] = {'channel_id': channel.id, 'ts': ts, 'config_name': 'default', 'user_id': user.id, 'text': 'x', 'send_at': '2026-01-01T00:00:00'}
+
+    with patch('bot.send_message'), patch('bot.flush_replies_cache', new=AsyncMock()):
+        await schedule_reply(app, "token", channel, config, "default", user, "x", ts)
+
+    assert key not in bot._scheduled_replies_cache


### PR DESCRIPTION
- Add `SCHEDULED_REPLIES_CACHE_FILE` env var and in‑memory cache for pending replies.
- Implement `load_replies_cache`, `flush_replies_cache`, and `restore_scheduled_replies` to manage cache persistence and reschedule unfinished replies on startup.
- Extend `schedule_reply` with `wait_time_override` and ensure cache entry is removed after the reply is sent.
- Store a cache entry each time a reply is scheduled, including send time and relevant metadata.
- Invoke cache loading and restoration during bot initialization.
- Add tests covering cache round‑trip, missing file handling, restoration logic for unknown channels, remaining time calculation, immediate execution for overdue replies, and cache cleanup after sending.
